### PR TITLE
Extend CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
 # soundcloud-related-tracks
+
+# track shape
+{
+  song_id: Number,
+  plays: Number,
+  likes: Number,
+  reposts: Number,
+  comments: Number,
+  genre: String,
+  onPlaylists: [Number],
+  producedBy: String,
+  likedBy: [Number],
+  playedBy: [Number],
+  repostedBy: [Number],
+}
+
+# related tracks song API request & response examples
+
+### GET /relatedTracks/[id]
+
+Example: http://localhost:3001/relatedTracks/[id]
+
+Response body:
+      {
+        "song_id": [id],
+        "plays": 5258,
+        "likes": 766,
+        "reposts": 83,
+        "onPlaylists": [67,71,10],
+        "likedBy": [65,89,4],
+        "playedBy": [83,20,41],
+        "repostedBy": [2,84,81],
+        "genre": "spoken",
+        "producedBy": "zaytoven",
+      }
+
+### POST /relatedTracks/[id]
+
+Example: Create - POST http://localhost:3001/relatedTracks/[id]
+
+Request body:
+      {
+        "song_id": [id],
+        "plays": 45,
+        "likes": 455,
+        "reposts": 4545,
+        "onPlaylists": [67,71,10],
+        "likedBy": [65,89,4],
+        "playedBy": [83,20,41],
+        "repostedBy": [2,84,81],
+        "genre": "ambient",
+        "producedBy": "stock boy",
+      }
+
+Response body:
+      "track [id] posted"
+
+
+### PUT /relatedTracks/[id]
+
+Example: Update - PUT http://localhost:3001/relatedTracks/[id]
+
+Request body:
+      {
+        "song_id": [id],
+        "plays": 45,
+        "likes": 455,
+        "reposts": 4545,
+        "onPlaylists": [67,71,10],
+        "likedBy": [65,89,4],
+        "playedBy": [83,20,41],
+        "repostedBy": [2,84,81],
+        "genre": "ambient",
+        "producedBy": "bialystock unt bloom",
+      }
+
+Response body:
+      "track [id] put on"
+
+### DELETE /relatedTracks/[id]
+
+Example: http://localhost:3001/relatedTracks/[id]
+
+Request body:
+      {
+        "song_id": [id],
+      }
+
+Response body:
+      "track [id] deleted"

--- a/client/relatedData.jsx
+++ b/client/relatedData.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
+import axios from 'axios';
 
 class RelatedTracks extends React.Component {
   constructor(props) {
@@ -15,11 +16,30 @@ class RelatedTracks extends React.Component {
   }
 
   updateRelated(data) {
-    this.setState({related: data});
+    data.onPlaylists.forEach((item, index) => {
+      this.addToRelated(item, index);
+    });
+  }
+
+  addToRelated(id, index) {
+    axios(`/relatedTracks/${id}`)
+    .then(({ data }) => {
+      data.song = `${10000000 - data.song_id} bottles of beer on the wall`;
+      data.band = `${data.song_id} bottlecaps`;
+      data.image = 'https://i1.sndcdn.com/avatars-000153260008-nj3jj1-t200x200.jpg';
+      if (index === 0) {
+        this.setState({
+          related: [data],
+        });
+      } else {
+        this.setState({
+          related: this.state.related.concat(data),
+        });
+      }
+    })
   }
 
   componentDidMount() {
-    // console.log('MOUNT STATE: 🤪', this.state);
     $.ajax(
       {
         url: `/relatedTracks/${this.song}`,
@@ -31,15 +51,13 @@ class RelatedTracks extends React.Component {
   }
 
   render() {
-    // console.log('RENDER STATE: 🥶', this.state);
-    return this.state.related.map(track => {
+    return this.state.related.map((track) => {
     let plays = [<span key={"spanPlays" + track.song_id}>&#9658;</span>, ` ${track.plays}`];
     let likes = [<span key={"spanLikes" + track.song_id} >&#9829;</span>, ` ${track.likes}`];
     let reposts = [<span key={"spanReposts" + track.song_id}>&#10226;</span>, ` ${track.reposts}`];
     let comments = [<span key={"spanComments" + track.song_id}>&#128488;</span>, ` 3`];
     let image = [<img key={"image" + track.song_id} className="nicholas related-tracks band-image" src={track.image}/>];
     let song = [<p key={"song" + track.song_id} className="nicholas related-tracks song">{track.song}</p>]
-    console.log(track);
     let band = [<p key={"band" + track.song_id} className="nicholas related-tracks band-name">{track.band}</p>]
     return (
       <>

--- a/relatedData.js
+++ b/relatedData.js
@@ -1,7 +1,10 @@
 const mongoose = require('mongoose');
 const chalk = require('chalk');
 
-mongoose.connect('mongodb://localhost/test');
+mongoose.connect('mongodb://localhost/tracks', {
+                                                  useUnifiedTopology: true,
+                                                  useNewUrlParser: true,
+                                                });
 
 const db = mongoose.connection;
 db.on('error', function() {
@@ -12,29 +15,44 @@ db.once('open', function() {
 });
 
 const relatedSchema = new mongoose.Schema({
-  song_id: {type: Number, unique: true},
+  song_id: Number,
   plays: Number,
   likes: Number,
   reposts: Number,
-  related: [Number]
+  comments: Number,
+  genre: String,
+  onPlaylists: [Number],
+  producedBy: String,
+  likedBy: [Number],
+  playedBy: [Number],
+  repostedBy: [Number],
 });
 
 const Track = mongoose.model('Track', relatedSchema);
 
-let saveTrack = function(trackData, cb) {
-  let track = new Track(trackData);
-  track.save((err, track) => {
+const addTrack = function(trackData, cb = () => {}) {
+  let trackId = trackData.song_id;
+  return findTrack(trackId, (err, data) => {
     if (err) {
-      console.log(chalk.red('Problem saving track', err));
-      cb(err);
+      console.log(err);
+    } else if (data === null) {
+      let track = new Track(trackData);
+      track.save((err, track) => {
+        if (err) {
+          console.log(chalk.red('Problem saving track', err));
+          cb(err);
+        } else {
+          console.log(chalk.blue(`Track ${track.song_id} saved`));
+          cb(null, track);
+        }
+      })
     } else {
-      console.log(chalk.blue(`Track ${track.song_id} saved`));
-      cb(null, track);
+      cb(null, false);
     }
   })
 };
 
-let findTrack = function(id, cb) {
+const findTrack = function(id, cb = () => {}) {
   Track.findOne({song_id: id}, (err, track) => {
     if (err) {
       cb(err);
@@ -44,7 +62,18 @@ let findTrack = function(id, cb) {
   })
 };
 
-let deleteTrack = function (id, cb) {
+const updateTrack = function(id, replacement, cb = () => {}) {
+  Track.findOneAndReplace({song_id: id}, replacement, { new: true }, (err, track) => {
+    if (err) {
+      cb(err);
+    } else {
+      console.log(track)
+      cb(null, track);
+    }
+  });
+};
+
+const deleteTrack = function (id, cb = () => {}) {
   Track.findOneAndDelete({song_id: id}, (err, track) => {
     if (err) {
       console.log(chalk.red('Could not delete track'));
@@ -56,6 +85,55 @@ let deleteTrack = function (id, cb) {
   })
 };
 
-module.exports.saveTrack = saveTrack;
-module.exports.findTrack = findTrack;
-module.exports.deleteTrack = deleteTrack;
+const drop = () => {
+  mongoose.connection.dropCollection('tracks', (err, result) => {
+    if (err) {
+      console.log('err: ', err);
+    } else {
+      console.log('tracks dropped');
+      console.log(result);
+    }
+  });
+};
+
+const close = () => {
+  mongoose.connection.close();
+};
+
+
+module.exports = {
+  addTrack,
+  findTrack,
+  updateTrack,
+  deleteTrack,
+  drop,
+  close,
+}
+
+// updateTrack(31,
+//   { song_id: 31 },
+//   (err, data) => {
+//     if (err) {
+//       console.log(`your err: ${err}`);
+//     } else {
+//       console.log(`your data: ${data}`);
+//     }
+//   }
+// );
+
+/**
+ * {
+  onPlaylists: [ 48, 95, 79 ],
+  likedBy: [ 37, 94, 47 ],
+  playedBy: [ 31, 66, 52 ],
+  repostedBy: [ 78, 12, 17 ],
+  _id: 5fb45f9d2385035c38743d9b,
+  song_id: 89,
+  plays: 8924,
+  likes: 491,
+  reposts: 47,
+  genre: 'jazz',
+  producedBy: 'bialystock unt bloom',
+  __v: 0
+}
+ */

--- a/relatedData.js
+++ b/relatedData.js
@@ -109,31 +109,3 @@ module.exports = {
   drop,
   close,
 }
-
-// updateTrack(31,
-//   { song_id: 31 },
-//   (err, data) => {
-//     if (err) {
-//       console.log(`your err: ${err}`);
-//     } else {
-//       console.log(`your data: ${data}`);
-//     }
-//   }
-// );
-
-/**
- * {
-  onPlaylists: [ 48, 95, 79 ],
-  likedBy: [ 37, 94, 47 ],
-  playedBy: [ 31, 66, 52 ],
-  repostedBy: [ 78, 12, 17 ],
-  _id: 5fb45f9d2385035c38743d9b,
-  song_id: 89,
-  plays: 8924,
-  likes: 491,
-  reposts: 47,
-  genre: 'jazz',
-  producedBy: 'bialystock unt bloom',
-  __v: 0
-}
- */

--- a/seedData.js
+++ b/seedData.js
@@ -1,52 +1,36 @@
-const relatedData = require('./relatedData.js');
+const { addTrack, findTrack, updateTrack, deleteTrack, drop, close } = require('./relatedData.js');
 const chalk = require('chalk');
 
+const genners = ['pop', 'rock', 'rap', 'r&b', 'punk', 'emo', 'classical', 'jazz', 'spoken', 'ambient'];
+
+const producers = ['dre', 'michael williams', 'zaytoven', 'bialystock unt bloom', 'stock boy'];
+
 let seedData = function() {
-  let completed = 0;
-  for (let i = 1; i <= 100; i++) {
-    let id = i;
-    relatedData.findTrack(id, (err, track) => {
-      if (err) {
-        console.log(chalk.red('No data: ', err));
-        i += 100;
-      } else {
-        relatedData.deleteTrack(id, (err, track) => {
-          if (err) {
-            console.log(chalk.red('Problem deleting for seed data: ', err));
-          } else {
-            completed++;
-            if (completed === 100) {
-              let seeded = 0;
-              for (let j = 1; j <= 100; j++) {
-                let info = {song_id: j};
-                info.plays = Math.floor(Math.random() * 11);
-                info.likes = Math.floor(Math.random() * 11);
-                info.reposts = Math.floor(Math.random() * 11);
-                info.related = [];
-                let similar = Math.floor(Math.random() * 4);
-                for (let k = 1; k <= similar; k++) {
-                  let num = Math.ceil(Math.random() * 100);
-                  info.related.push(num);
-                }
-                relatedData.saveTrack(info, (err, data) => {
-                  if (err) {
-                    console.log(chalk.red('Problem seeding data: ', err));
-                  } else {
-                    seeded++;
-                    console.log(chalk.blue(data));
-                    if (seeded === 100) {
-                      console.log(chalk.green('Seeding complete'));
-                      return;
-                    }
-                  }
-                })
-              }
-            }
-          }
-        })
-      }
-    })
-  }
+  return new Promise((resolve, reject) => {
+    drop();
+    resolve();
+  })
+  .then(() => {
+    for (let i = 1; i <= 100; i += 1) {
+      let current = {
+        song_id: i,
+        plays: Math.ceil(Math.random() * 10000),
+        likes: Math.ceil(Math.random() * 1000),
+        reposts: Math.ceil(Math.random() * 100),
+        comments: Math.ceil(Math.random() * 100),
+        genre: genners[Math.floor(Math.random() * genners.length)],
+        onPlaylists: [Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100)],
+        producedBy: producers[Math.floor(Math.random() * producers.length)],
+        likedBy: [Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100)],
+        playedBy: [Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100)],
+        repostedBy: [Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100), Math.ceil(Math.random() * 100)],
+      };
+      addTrack(current, () => {});
+    }
+  })
+  .catch((err) => {
+    console.log(`seeding err: ${err}`);
+  });
 };
 
 seedData();

--- a/server/index.js
+++ b/server/index.js
@@ -2,11 +2,16 @@ const express = require('express');
 const path = require('path');
 const chalk = require('chalk');
 const axios = require('axios');
-const db = require('../relatedData.js');
+const parser = require('body-parser');
+const morgan = require('morgan');
+const { addTrack, findTrack, updateTrack, deleteTrack, drop, close } = require('../relatedData.js');
 const expressStaticGzip = require('express-static-gzip');
 const app = express();
 
 const port = 3001;
+
+app.use(parser.json());
+app.use(morgan('dev'));
 
 // app.use(express.static(path.join(__dirname, '../public')));
 app.use('/', expressStaticGzip(path.join(__dirname, '../public'), {
@@ -17,60 +22,94 @@ app.use('/', expressStaticGzip(path.join(__dirname, '../public'), {
    }
 }))
 
-app.get('/relatedTracks/:song', (req, res) => {
-  // console.log(chalk.bgWhite.black(req.params.song));
-  db.findTrack(req.params.song, (err, data) => {
+// /relatedTracks/:song API
+app.post('/relatedTracks/:song', (req, res) => {
+  const track = {
+    'song_id': req.params.song,
+    'plays': req.body.plays,
+    'likes': req.body.likes,
+    'reposts': req.body.reposts,
+    'comments': req.body.comments,
+    'genre': req.body.genre,
+    'onPlaylists': req.body.onPlaylists,
+    'producedBy': req.body.producedBy,
+    'likedBy': req.body.likedBy,
+    'playedBy': req.body.playedBy,
+    'repostedBy': req.body.repostedBy,
+  };
+  addTrack(track, (err, data) => {
     if (err) {
-      console.log(chalk.red(`Problem obtaining track info: `, err));
-      res.status(500).send('There was a problem getting the track info');
+      console.log(`post err: ${err}`);
+      res.status(500).send('we had trouble adding that track; try again later');
     } else {
-      let relatedInfo = [];
-      if (data.related.length === 0) {
-        res.send(relatedInfo);
-      }
-      for (let i = 0; i < data.related.length; i++) {
-        let trackInfo = {};
-        trackInfo.song_id = data.related[i];
-        db.findTrack(data.related[i], (err, info) => {
-          if (err) {
-            console.log(chalk.red(`Can't find secondary track info: `, err));
-            res.status(500).send('Problem locating related track data');
-          } else {
-            trackInfo.plays = info.plays;
-            trackInfo.likes = info.likes;
-            trackInfo.reposts = info.reposts;
-            axios.get(`http://52.37.102.63:3005/songdata/${trackInfo.song_id}`)
-            .then(function (response) {
-              trackInfo.image = response.data.songImage;
-              trackInfo.song = response.data.songName;
-            })
-            .catch(function (error) {
-              console.log('ERROR GETTING IMAGE AND SONG NAME', error);
-              trackInfo.image = 'https://i1.sndcdn.com/avatars-000153260008-nj3jj1-t200x200.jpg';
-              trackInfo.song = 'Last Chance';
-            })
-            .then (function() {
-              axios.get(`http://34.220.154.45:2000/artistBio/${trackInfo.song_id}`)
-                .then(function (response) {
-                  trackInfo.band = response.data.data.bandName;
-                })
-                .catch(function (error) {
-                  console.log('ERROR GETTING BAND NAME', error);
-                  trackInfo.band = 'LionsBesideUs';
-                })
-                .then (function() {
-                  relatedInfo.push(trackInfo);
-                  if (relatedInfo.length === data.related.length) {
-                    res.send(relatedInfo);
-                  }
-                })
-            })
-          }
-        })
+      if (data === false) {
+        res.status(404).send('Track already exists');
+      } else {
+        res.status(200).send(`Track ${req.params.song} added`);
       }
     }
   })
-})
+});
+
+app.get('/relatedTracks/:song', (req, res) => {
+  findTrack(req.params.song, (err, data) => {
+    if (err) {
+      console.log(chalk.red(`Problem obtaining track info: ${err}`));
+      res.status(500).send('we had trouble finding that track; try again later');
+    } else {
+      if (data === null) {
+        res.status(404).send('No such track');
+      } else {
+        res.send(data);
+      }
+    }
+  });
+});
+
+app.put('/relatedTracks/:song', (req, res) => {
+  const replacement = {
+    'song_id': req.params.song,
+    'plays': req.body.plays,
+    'likes': req.body.likes,
+    'reposts': req.body.reposts,
+    'comments': req.body.comments,
+    'genre': req.body.genre,
+    'onPlaylists': req.body.onPlaylists,
+    'producedBy': req.body.producedBy,
+    'likedBy': req.body.likedBy,
+    'playedBy': req.body.playedBy,
+    'repostedBy': req.body.repostedBy,
+  };
+  updateTrack(req.params.song, replacement, (err, track) => {
+    if (err) {
+      console.log(`put error: ${err}`);
+      res.status(500).end('we had trouble updating that track; try again later');
+    } else {
+      if (track === null || !track.song_id) {
+        res.status(404).send('no such track');
+      } else {
+        console.log(`put data: ${track}`);
+        res.status(200).send(`track ${track.song_id} put on`);
+      }
+    }
+  });
+});
+
+app.delete('/relatedTracks/:song', (req, res) => {
+  let song = req.params.song;
+  deleteTrack(song, (err, track) => {
+    if (err) {
+      console.log(`delete error: ${err}`);
+      res.status(500).end('we had trouble deleting that track; try again later');
+    } else {
+      if (track === null) {
+        res.status(404).send('no such track');
+      } else {
+        res.status(200).send(`track ${track.song_id} deleted`);
+      }
+    }
+  });
+});
 
 app.get('/:current', (req, res) => {
   res.sendFile(path.join(__dirname,'../public/index.html'));

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const path = require('path');
 const chalk = require('chalk');
-const axios = require('axios');
 const parser = require('body-parser');
 const morgan = require('morgan');
 const { addTrack, findTrack, updateTrack, deleteTrack, drop, close } = require('../relatedData.js');


### PR DESCRIPTION
Still in the process of reworking tests from legacy codebase, but have tested these endpoints in Postman.

### README.md
The changes here are fairly simple, just documenting the API that has been built out below.

### client/relatedData.jsx
More simple changes. I've added new API calls here, so as not to have to deal w/ recursive server routing for the time being.

### relatedData.js
I've built out the database to have methods for all the CRUD operations. I've also made the data more complex based on some discussions with Leslie. 

### seedData.js
I've updated the seeding script to work with my newly designed data.

### server/index.js
I've added CrUD methods and rewritten the cRud method in order to work with my data.